### PR TITLE
Feat/predev scripts (#38)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,4 @@
+require("dotenv").config()
 const gulp = require("gulp")
 const sass = require("gulp-sass")
 const autoprefixer = require("gulp-autoprefixer")
@@ -5,7 +6,7 @@ const sourcemaps = require("gulp-sourcemaps")
 const uglify = require("gulp-uglify")
 const concat = require("gulp-concat")
 const browserSync = require('browser-sync').create()
-const port = 2999
+const port = process.env.PORT
 
 gulp.task("css", () => {
   return gulp

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,8 @@ const autoprefixer = require("gulp-autoprefixer")
 const sourcemaps = require("gulp-sourcemaps")
 const uglify = require("gulp-uglify")
 const concat = require("gulp-concat")
+const browserSync = require('browser-sync').create()
+const port = 2999
 
 gulp.task("css", () => {
   return gulp
@@ -14,6 +16,18 @@ gulp.task("css", () => {
     .pipe(sourcemaps.write())
     .pipe(sass({ outputStyle: "compressed" }))
     .pipe(gulp.dest("dist/css"))
+    .pipe(browserSync.reload({
+      stream: true
+    }))
+})
+
+gulp.task('watch', () => {
+  browserSync.init({
+    proxy: `localhost:${port}`
+  })
+  // Watchers
+  gulp.watch('./src/**/*.scss', gulp.series('css'))
+  gulp.watch('./views/*.hbs', browserSync.reload)
 })
 
 gulp.task("js", () => {

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
     "node": "^15.12.0"
   },
   "scripts": {
-    "predev": "npm run build:css",
+    "predev": "npm run build",
     "dev": "nodemon index.js",
-    "prebuild:css": "rimraf ./dist/css",
-    "build:css": "gulp css",
     "watch:css": "gulp watch",
+    "prebuild": "rimraf ./dist/css && rimraf ./dist/js",
+    "build": "gulp",
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   }

--- a/package.json
+++ b/package.json
@@ -15,13 +15,15 @@
   "homepage": "https://github.com/deannabosschert/Matcher#readme",
   "main": "index.js",
   "devDependencies": {
+    "browser-sync": "^2.26.14",
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^8.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-sass": "^4.1.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-uglify": "^3.0.2",
-    "nodemon": "^2.0.2"
+    "nodemon": "^2.0.2",
+    "rimraf": "^3.0.2"
   },
   "dependencies": {
     "compression": "^1.7.4",
@@ -40,8 +42,11 @@
     "node": "^15.12.0"
   },
   "scripts": {
+    "predev": "npm run build:css",
     "dev": "nodemon index.js",
-    "build": "gulp",
+    "prebuild:css": "rimraf ./dist/css",
+    "build:css": "gulp css",
+    "watch:css": "gulp watch",
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   }


### PR DESCRIPTION
What do you guys think about these changes to the gulpfile and package, ive included:

1. a predev script which runs build:css
2. a prebuild:css script which removes the dist/src folder so build:css can create a new one from he css file in `src/scss/*`
3. a watch:css script which can be run in a seperate terminal `npm run watch:css` which proxies our port from localhost:2999 to localhost:3000, it watches the following directories and files for changes: 
```javascript
  gulp.watch('./src/**/*.scss', gulp.series('css'))
  gulp.watch('./views/*.hbs', browserSync.reload)
```
if any changes are made to files in these directories browser-sync instantly refreshes your proxied page (localhost:3000).

Ive also removed a script which called for "gulp" which is not a specified task in the gulpfile, do you need this script Daniel?

Anyway its not a necessary change but its one i made because the css in dist needs a script to be built and the watch:css script is very handy when you want to make css changes!

In summary:

- included a predev script which builds our css from our sourcemap
- included a watch:css script with browser-sync to automatically refresh your localhost when you make changes to hbs or scss files